### PR TITLE
BUGFIX: Fixed a issue when all positions inside of a order are digital.

### DIFF
--- a/src/Core/Api/WebHooks/Controller/WebHookController.php
+++ b/src/Core/Api/WebHooks/Controller/WebHookController.php
@@ -646,6 +646,11 @@ class WebHookController extends AbstractController {
 			 * @var OrderDeliveryEntity $orderDelivery
 			 */
 			$orderDelivery = $order->getDeliveries()->last();
+            
+            if (is_null($orderDelivery)) {
+                return;
+            }
+
 			if ($orderDelivery->getStateMachineState()?->getTechnicalName() !== OrderDeliveryStateHandler::STATE_HOLD){
 				return;
 			}

--- a/src/Core/Api/WebHooks/Controller/WebHookController.php
+++ b/src/Core/Api/WebHooks/Controller/WebHookController.php
@@ -646,10 +646,10 @@ class WebHookController extends AbstractController {
 			 * @var OrderDeliveryEntity $orderDelivery
 			 */
 			$orderDelivery = $order->getDeliveries()->last();
-            
-            if (is_null($orderDelivery)) {
-                return;
-            }
+
+			if (is_null($orderDelivery)) {
+				return;
+			}
 
 			if ($orderDelivery->getStateMachineState()?->getTechnicalName() !== OrderDeliveryStateHandler::STATE_HOLD){
 				return;


### PR DESCRIPTION
When you have a order in Shopware with only digital products there will be no order delivery.
Therefore the transaction webhook will fail and throw a manual task which cannot be resolved by the admin.